### PR TITLE
Improved project & code structure

### DIFF
--- a/heat2d/stage.py
+++ b/heat2d/stage.py
@@ -6,8 +6,5 @@ class Stage:
     def __repr__(self):
         return f"<heat2d.stage.Stage()>"
 
-    def __str__(self):
-        return self.__repr__()
-
     def update(self):
         pass


### PR DESCRIPTION
It is not required nor useful to include a `__str__` method if it should return the same as `__repr__`.